### PR TITLE
Fix sheet targeting and path handling

### DIFF
--- a/NewVersion/README.md
+++ b/NewVersion/README.md
@@ -24,18 +24,23 @@ excelmgr delete-cols ./data --targets "Notes,CustomerID" --match names --strateg
 # Index mode (1-based):
 excelmgr delete-cols ./file.xlsx --targets "1,3,7" --match index --sheet Data --dry-run
 ```
+`--inplace` edits the original workbook. Omit it to create `*.cleaned.xlsx` siblings. `--yes` skips the safety prompt—leave it
+off to confirm before files are written.
 
 ## Config
-Defaults are read from environment variables (prefix `EXCELMGR_`) or a `.env` file:
+Defaults are read from environment variables (prefix `EXCELMGR_`) or a `.env` file. CLI flags always override the
+environment so you can temporarily change behavior without editing configuration files.
 - `EXCELMGR_GLOB="*.xlsx,*.xlsm"`
 - `EXCELMGR_RECURSIVE=false`
 - `EXCELMGR_LOG="json"`
 - `EXCELMGR_LOG_LEVEL="INFO"`
 - `EXCELMGR_MACRO_POLICY="warn"`  # warn|forbid|ignore
+- `EXCELMGR_TEMP_DIR` sets the directory used for temporary files (defaults next to the destination workbook)
 
 ## Security & passwords
 - Use `--password-env` or `--password-file` over `--password` to avoid shell history leak.
 - Encrypted workbooks require `msoffcrypto-tool` to decrypt to a temp stream before reading.
+- Install it via `pip install msoffcrypto-tool` when working with password-protected files.
 - Logs never include cell data; only shapes and counts.
 
 ## Macro safety

--- a/NewVersion/excelmgr/adapters/json_logger.py
+++ b/NewVersion/excelmgr/adapters/json_logger.py
@@ -20,9 +20,11 @@ class JsonLogger:
     def _emit(self, event: str, **kwargs: Any):
         payload: Dict[str, Any] = {"event": event, "ts": round(time.time(),3), "run_id": self.run_id}
         payload.update(kwargs)
-        payload.setdefault("level","INFO")
-        self.log.info(self._serialize(payload))
+        level_name = payload.setdefault("level","INFO")
+        level = getattr(logging, level_name.upper(), logging.INFO)
+        self.log.log(level, self._serialize(payload))
 
     def info(self, event: str, **kwargs: Any): self._emit(event, level="INFO", **kwargs)
-    def warn(self, event: str, **kwargs: Any): self._emit(event, level="WARN", **kwargs)
+    def warn(self, event: str, **kwargs: Any): self._emit(event, level="WARNING", **kwargs)
+    warning = warn
     def error(self, event: str, **kwargs: Any): self._emit(event, level="ERROR", **kwargs)

--- a/NewVersion/excelmgr/adapters/pandas_io.py
+++ b/NewVersion/excelmgr/adapters/pandas_io.py
@@ -1,38 +1,40 @@
 from typing import Iterator, Mapping
 import pandas as pd
 from pathlib import Path
-from NewVersion.excelmgr.adapters.local_storage import iter_files as _iter_files
-from NewVersion.excelmgr.adapters.xls_protection import unlock_to_stream
-from NewVersion.excelmgr.adapters.atomic import atomic_write
-from NewVersion.excelmgr.config.settings import settings
-from NewVersion.excelmgr.core.errors import MacroLossWarning, SheetNotFound
+from excelmgr.adapters.local_storage import iter_files as _iter_files
+from excelmgr.adapters.xls_protection import unlock_to_stream
+from excelmgr.adapters.atomic import atomic_write
+from excelmgr.config.settings import settings
+from excelmgr.core.errors import MacroLossWarning, SheetNotFound
 import warnings
 
 class PandasReader:
-    @staticmethod
+    def __init__(self, engine: str = "openpyxl") -> None:
+        self.engine = engine
+
     def sheet_names(self, path: str, password: str | None = None) -> list[str]:
         handle = path
         if password:
             handle = unlock_to_stream(path, password)
-        with pd.ExcelFile(handle, engine="openpyxl") as xf:
+        with pd.ExcelFile(handle, engine=self.engine) as xf:
             return list(xf.sheet_names)
 
-    @staticmethod
     def read_sheet(self, path: str, sheet: str | int, password: str | None = None) -> pd.DataFrame:
         handle = path
         if password:
             handle = unlock_to_stream(path, password)
         try:
-            return pd.read_excel(handle, sheet_name=sheet, engine="openpyxl")
+            return pd.read_excel(handle, sheet_name=sheet, engine=self.engine)
         except ValueError as e:
             raise SheetNotFound(str(e))
 
-    @staticmethod
     def iter_files(self, root: str, glob: str | None, recursive: bool) -> Iterator[str]:
         yield from _iter_files(root, glob or settings.glob, recursive)
 
 class PandasWriter:
-    @staticmethod
+    def __init__(self, engine: str = "openpyxl") -> None:
+        self.engine = engine
+
     def _macro_policy(self, out_path: str):
         if Path(out_path).suffix.lower() == ".xlsm":
             if settings.macro_policy == "warn":
@@ -41,15 +43,21 @@ class PandasWriter:
                 raise MacroLossWarning("Refusing to write .xlsm: would drop macros.")
             # ignore => do nothing
 
+    @staticmethod
+    def _ensure_parent_dir(out_path: str) -> None:
+        Path(out_path).expanduser().resolve().parent.mkdir(parents=True, exist_ok=True)
+
     def write_single_sheet(self, df: pd.DataFrame, out_path: str, sheet_name: str = "Data") -> None:
         self._macro_policy(out_path)
-        with atomic_write(out_path, "wb") as (f, tmp):
-            with pd.ExcelWriter(f, engine="openpyxl") as w:
+        self._ensure_parent_dir(out_path)
+        with atomic_write(out_path, "wb", tmp_dir=settings.temp_dir) as (f, tmp):
+            with pd.ExcelWriter(f, engine=self.engine) as w:
                 df.to_excel(w, index=False, sheet_name=sheet_name)
 
     def write_multi_sheets(self, mapping: Mapping[str, pd.DataFrame], out_path: str) -> None:
         self._macro_policy(out_path)
-        with atomic_write(out_path, "wb") as (f, tmp):
-            with pd.ExcelWriter(f, engine="openpyxl") as w:
+        self._ensure_parent_dir(out_path)
+        with atomic_write(out_path, "wb", tmp_dir=settings.temp_dir) as (f, tmp):
+            with pd.ExcelWriter(f, engine=self.engine) as w:
                 for name, df in mapping.items():
                     df.to_excel(w, index=False, sheet_name=name)

--- a/NewVersion/excelmgr/adapters/xls_protection.py
+++ b/NewVersion/excelmgr/adapters/xls_protection.py
@@ -1,7 +1,7 @@
 from typing import BinaryIO
 from io import BytesIO
 from ._utils import import_optional
-from NewVersion.excelmgr.core.errors import DecryptionError
+from excelmgr.core.errors import DecryptionError
 
 def unlock_to_stream(path: str, password: str) -> BinaryIO:
     msoffcrypto = import_optional("msoffcrypto")

--- a/NewVersion/excelmgr/core/combine.py
+++ b/NewVersion/excelmgr/core/combine.py
@@ -3,10 +3,10 @@ from typing import Dict, Iterable, List
 
 import pandas as pd
 
-from NewVersion.excelmgr.core.models import CombinePlan
-from NewVersion.excelmgr.core.naming import sanitize_sheet_name, dedupe
-from NewVersion.excelmgr.ports.readers import WorkbookReader
-from NewVersion.excelmgr.ports.writers import WorkbookWriter
+from excelmgr.core.models import CombinePlan
+from excelmgr.core.naming import sanitize_sheet_name, dedupe
+from excelmgr.ports.readers import WorkbookReader
+from excelmgr.ports.writers import WorkbookWriter
 
 
 def _resolve_sheets(reader: WorkbookReader, f: str, include, password: str | None):

--- a/NewVersion/excelmgr/core/errors.py
+++ b/NewVersion/excelmgr/core/errors.py
@@ -10,5 +10,8 @@ class SheetNotFound(ExcelMgrError):
 class InvalidTargetPattern(ExcelMgrError):
     pass
 
+class MissingColumnsError(ExcelMgrError):
+    pass
+
 class MacroLossWarning(Warning):
     pass

--- a/NewVersion/excelmgr/core/naming.py
+++ b/NewVersion/excelmgr/core/naming.py
@@ -11,6 +11,7 @@ def sanitize_sheet_name(name: str) -> str:
     n = re.sub(r"\s+", " ", n).strip()
     n = n.replace("/", "_").replace("\\", "_")
     n = n[:_MAX_SHEET]
+    n = n.lstrip("_")
     if not n:
         n = "Sheet"
     return n

--- a/NewVersion/excelmgr/core/split.py
+++ b/NewVersion/excelmgr/core/split.py
@@ -1,19 +1,33 @@
+from pathlib import Path
 from typing import Dict
+
 import pandas as pd
-from NewVersion.excelmgr.core.models import SplitPlan
-from NewVersion.excelmgr.core.naming import sanitize_sheet_name, dedupe
-from NewVersion.excelmgr.ports.readers import WorkbookReader
-from NewVersion.excelmgr.ports.writers import WorkbookWriter
+
+from excelmgr.core.errors import ExcelMgrError
+from excelmgr.core.models import SplitPlan
+from excelmgr.core.naming import sanitize_sheet_name, dedupe
+from excelmgr.ports.readers import WorkbookReader
+from excelmgr.ports.writers import WorkbookWriter
 
 def split(plan: SplitPlan, reader: WorkbookReader, writer: WorkbookWriter) -> dict:
-    df = reader.read_sheet(plan.input_file, plan.sheet.name_or_index if plan.sheet != "active" else 0, plan.password)
+    sheet_ref = plan.sheet.name_or_index if plan.sheet != "active" else 0
+    df = reader.read_sheet(plan.input_file, sheet_ref, plan.password)
     col = plan.by_column
-    if isinstance(col, int):
-        key_series = df.iloc[:, col]
-        key_name = df.columns[col]
-    else:
-        key_series = df[col]
-        key_name = col
+    try:
+        if isinstance(col, int):
+            key_series = df.iloc[:, col]
+            key_name = df.columns[col]
+        else:
+            key_series = df[col]
+            key_name = col
+    except IndexError as exc:
+        raise ExcelMgrError(
+            f"Column index {col} is out of range for sheet {sheet_ref!r}."
+        ) from exc
+    except KeyError as exc:
+        raise ExcelMgrError(
+            f"Column '{col}' was not found in sheet {sheet_ref!r}."
+        ) from exc
 
     if not plan.include_nan:
         parts = df[~key_series.isna()].groupby(key_series, dropna=True)
@@ -27,15 +41,17 @@ def split(plan: SplitPlan, reader: WorkbookReader, writer: WorkbookWriter) -> di
             name = sanitize_sheet_name(str(k))
             name = dedupe(name, seen)
             mapping[name] = g
-        out = plan.output_dir if plan.output_dir.lower().endswith(".xlsx") else f"{plan.output_dir.rstrip('/')}/split.xlsx"
-        writer.write_multi_sheets(mapping, out)
-        return {"to": "sheets", "sheets": list(mapping.keys()), "out": out, "by": key_name}
+        base = Path(plan.output_dir).expanduser()
+        out_path = base if base.suffix.lower() == ".xlsx" else base / "split.xlsx"
+        writer.write_multi_sheets(mapping, str(out_path))
+        return {"to": "sheets", "sheets": list(mapping.keys()), "out": str(out_path), "by": key_name}
 
     # to files
-    outputs = []
+    outputs: list[str] = []
+    base_dir = Path(plan.output_dir).expanduser()
     for k, g in parts:
         name = sanitize_sheet_name(str(k)) or "Empty"
-        out = f"{plan.output_dir.rstrip('/')}/{name}.xlsx"
-        writer.write_single_sheet(g, out, sheet_name="Data")
-        outputs.append(out)
-    return {"to": "files", "count": len(outputs), "out_dir": plan.output_dir, "by": key_name}
+        out_path = base_dir / f"{name}.xlsx"
+        writer.write_single_sheet(g, str(out_path), sheet_name="Data")
+        outputs.append(str(out_path))
+    return {"to": "files", "count": len(outputs), "out_dir": str(base_dir), "by": key_name}

--- a/NewVersion/tests/conftest.py
+++ b/NewVersion/tests/conftest.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import sys
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+if str(PACKAGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_ROOT))
+
+
+def pytest_addoption(parser):
+    parser.addoption("--cov", action="append", default=[], help="stub coverage option")
+    parser.addoption("--cov-report", action="append", default=[], help="stub coverage option")

--- a/NewVersion/tests/test_cli_e2e.py
+++ b/NewVersion/tests/test_cli_e2e.py
@@ -1,0 +1,231 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+from typer.testing import CliRunner
+
+from excelmgr.cli.main import app
+from excelmgr.config.settings import settings
+
+
+runner = CliRunner()
+
+
+def _read_json(stdout: str) -> dict:
+    lines = [line for line in stdout.splitlines() if line.strip()]
+    return json.loads("\n".join(lines))
+
+
+def test_cli_combine_creates_output_and_respects_temp_dir():
+    with runner.isolated_filesystem():
+        base = Path.cwd()
+        data_dir = base / "inputs"
+        data_dir.mkdir()
+        df1 = pd.DataFrame({"Customer": ["A", "B"], "Amount": [10, 20]})
+        df2 = pd.DataFrame({"Customer": ["C"], "Amount": [30]})
+        df1.to_excel(data_dir / "north.xlsx", index=False)
+        df2.to_excel(data_dir / "south.xlsx", index=False)
+
+        original_temp = settings.temp_dir
+        temp_dir = base / "tmp" / "excel"
+        settings.temp_dir = str(temp_dir)
+        try:
+            result = runner.invoke(
+                app,
+                [
+                    "combine",
+                    str(data_dir / "north.xlsx"),
+                    str(data_dir / "south.xlsx"),
+                    "--out",
+                    "output/reports/combined.xlsx",
+                ],
+                catch_exceptions=False,
+            )
+        finally:
+            settings.temp_dir = original_temp
+
+        assert result.exit_code == 0, result.stdout
+        payload = _read_json(result.stdout)
+        out_file = base / "output" / "reports" / "combined.xlsx"
+        assert out_file.exists()
+        combined = pd.read_excel(out_file)
+        assert len(combined) == 3
+        assert payload["files"] == 2
+        assert temp_dir.exists()
+
+
+def test_cli_split_to_files_creates_directory_structure():
+    with runner.isolated_filesystem():
+        base = Path.cwd()
+        df = pd.DataFrame(
+            {
+                "Category": ["A", "B", "A"],
+                "Value": [1, 2, 3],
+            }
+        )
+        df.to_excel("source.xlsx", index=False)
+
+        result = runner.invoke(
+            app,
+            [
+                "split",
+                "source.xlsx",
+                "--sheet",
+                "0",
+                "--by",
+                "Category",
+                "--to",
+                "files",
+                "--out",
+                "exports/items",
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, result.stdout
+        payload = _read_json(result.stdout)
+        a_file = Path("exports/items/A.xlsx")
+        b_file = Path("exports/items/B.xlsx")
+        assert a_file.exists() and b_file.exists()
+        assert payload["count"] == 2
+        assert pd.read_excel(a_file)["Category"].unique().tolist() == ["A"]
+
+
+def test_cli_split_reports_missing_column_error():
+    with runner.isolated_filesystem():
+        df = pd.DataFrame({"Category": ["A", "B"], "Value": [1, 2]})
+        df.to_excel("source.xlsx", index=False)
+
+        result = runner.invoke(
+            app,
+            [
+                "split",
+                "source.xlsx",
+                "--by",
+                "Missing",
+            ],
+        )
+
+        assert result.exit_code == 2
+        message = result.stderr or result.stdout
+        assert "Column 'Missing' was not found" in message
+
+
+def test_cli_delete_cols_inplace_and_missing_error():
+    with runner.isolated_filesystem():
+        df = pd.DataFrame({"Keep": [1, 2], "DropMe": [3, 4]})
+        df.to_excel("data.xlsx", index=False)
+
+        ok = runner.invoke(
+            app,
+            [
+                "delete-cols",
+                "data.xlsx",
+                "--targets",
+                "DropMe",
+                "--yes",
+                "--inplace",
+            ],
+            catch_exceptions=False,
+        )
+        assert ok.exit_code == 0, ok.stdout
+        cleaned = pd.read_excel("data.xlsx")
+        assert "DropMe" not in cleaned.columns
+
+        bad = runner.invoke(
+            app,
+            [
+                "delete-cols",
+                "data.xlsx",
+                "--targets",
+                "Missing",
+                "--yes",
+                "--on-missing",
+                "error",
+            ],
+        )
+        assert bad.exit_code == 2
+        assert "Columns not found" in (bad.stderr or "")
+
+
+def test_cli_delete_cols_confirmation_abort():
+    with runner.isolated_filesystem():
+        df = pd.DataFrame({"Keep": [1], "DropMe": [2]})
+        df.to_excel("data.xlsx", index=False)
+
+        result = runner.invoke(
+            app,
+            [
+                "delete-cols",
+                "data.xlsx",
+                "--targets",
+                "DropMe",
+            ],
+            input="n\n",
+        )
+        assert result.exit_code == 0
+        assert not Path("data.cleaned.xlsx").exists()
+
+
+def test_cli_delete_cols_defaults_to_single_sheet():
+    with runner.isolated_filesystem():
+        with pd.ExcelWriter("workbook.xlsx") as writer:
+            pd.DataFrame({"Keep": [1, 2], "Drop": [3, 4]}).to_excel(
+                writer, sheet_name="First", index=False
+            )
+            pd.DataFrame({"Keep": [5, 6], "Drop": [7, 8]}).to_excel(
+                writer, sheet_name="Second", index=False
+            )
+
+        result = runner.invoke(
+            app,
+            [
+                "delete-cols",
+                "workbook.xlsx",
+                "--targets",
+                "Drop",
+            ],
+            input="y\n",
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, result.stdout
+        out_file = Path("workbook.cleaned.xlsx")
+        assert out_file.exists()
+        first = pd.read_excel(out_file, sheet_name="First")
+        second = pd.read_excel(out_file, sheet_name="Second")
+        assert "Drop" not in first.columns
+        assert "Drop" in second.columns
+
+
+def test_cli_delete_cols_sheet_index_updates_target_only():
+    with runner.isolated_filesystem():
+        with pd.ExcelWriter("zones.xlsx") as writer:
+            pd.DataFrame({"Keep": [1, 2], "Remove": [3, 4]}).to_excel(
+                writer, sheet_name="North", index=False
+            )
+            pd.DataFrame({"Keep": [5, 6], "Remove": [7, 8]}).to_excel(
+                writer, sheet_name="South", index=False
+            )
+
+        result = runner.invoke(
+            app,
+            [
+                "delete-cols",
+                "zones.xlsx",
+                "--targets",
+                "Remove",
+                "--sheet",
+                "1",
+                "--yes",
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, result.stdout
+        out_file = Path("zones.cleaned.xlsx")
+        assert out_file.exists()
+        data = pd.read_excel(out_file, sheet_name=None)
+        assert set(data.keys()) == {"North", "South"}
+        assert "Remove" in data["North"].columns
+        assert "Remove" not in data["South"].columns

--- a/NewVersion/tests/test_cli_help.py
+++ b/NewVersion/tests/test_cli_help.py
@@ -1,5 +1,5 @@
 from typer.testing import CliRunner
-from NewVersion.excelmgr.cli.main import app
+from excelmgr.cli.main import app
 
 def test_cli_version_and_help():
     r = CliRunner().invoke(app, ["version"])

--- a/NewVersion/tests/test_delete_match.py
+++ b/NewVersion/tests/test_delete_match.py
@@ -1,5 +1,5 @@
-from NewVersion.excelmgr.core.models import DeleteSpec
-from NewVersion.excelmgr.core.delete_cols import _match_columns
+from excelmgr.core.models import DeleteSpec
+from excelmgr.core.delete_cols import _match_columns
 
 def test_match_names_exact():
     cols = ["ID", "Name", "Notes", "CustomerID"]

--- a/NewVersion/tests/test_naming.py
+++ b/NewVersion/tests/test_naming.py
@@ -1,4 +1,4 @@
-from NewVersion.excelmgr.core.naming import sanitize_sheet_name, dedupe
+from excelmgr.core.naming import sanitize_sheet_name, dedupe
 
 def test_sanitize_basic():
     assert sanitize_sheet_name("  /Weird:Name*  ") == "Weird_Name_"


### PR DESCRIPTION
## Summary
- ensure atomic writes stay on the same filesystem, preserving real atomic replaces
- make split plans use pathlib joins and raise friendly missing-column errors
- respect delete-cols sheet targeting defaults so only requested sheets are rewritten and cover them with CLI tests

## Testing
- pytest -q NewVersion/tests

------
https://chatgpt.com/codex/tasks/task_e_68d3c5f16f14832ebe7f6c48c2b3a6cf