### PR TITLE
Fix naming dedupe and file handling issues

### DIFF
--- a/src/excelmgr/core/combine.py
+++ b/src/excelmgr/core/combine.py
@@ -22,6 +22,8 @@ def _resolve_sheets(reader: WorkbookReader, f: str, include, password: str | Non
 
 def _iter_input_files(reader: WorkbookReader, inputs: Iterable[str], glob: str | None, recursive: bool) -> Iterable[str]:
     for item in inputs:
+        if os.path.basename(item).startswith("~$"):
+            continue
         if os.path.isdir(item):
             yield from reader.iter_files(item, glob, recursive)
         else:

--- a/src/excelmgr/core/delete_cols.py
+++ b/src/excelmgr/core/delete_cols.py
@@ -94,7 +94,10 @@ def delete_columns(spec: DeleteSpec, reader: WorkbookReader, writer: WorkbookWri
     if os.path.isdir(spec.path):
         paths = list(iter_files(spec.path, spec.glob, spec.recursive))
     else:
-        paths = [spec.path]
+        if os.path.basename(spec.path).startswith("~$"):
+            paths = []
+        else:
+            paths = [spec.path]
 
     summary = []
     missing_records: list[dict] = []

--- a/src/excelmgr/core/naming.py
+++ b/src/excelmgr/core/naming.py
@@ -1,23 +1,30 @@
 import re
+from typing import Final
 
-_MAX_SHEET = 31
-_ILLEGAL = r'[:\\/?*\[\]]'
+_MAX_SHEET: Final[int] = 31
+_ILLEGAL_PATTERN: Final[re.Pattern[str]] = re.compile(r"[\\/:?*\[\]]")
+_CTRL_PATTERN: Final[re.Pattern[str]] = re.compile(r"[\x00-\x1F]")
+
 
 def sanitize_sheet_name(name: str) -> str:
     n = str(name).strip()
     if not n:
         n = "Empty"
-    n = re.sub(_ILLEGAL, "_", n)
+    # Replace control characters and Excel-illegal characters with safe underscores
+    n = _CTRL_PATTERN.sub("_", n)
+    n = _ILLEGAL_PATTERN.sub("_", n)
     n = re.sub(r"\s+", " ", n).strip()
-    n = n.replace("/", "_").replace("\\", "_")
     n = n[:_MAX_SHEET]
     n = n.lstrip("_")
     if not n:
         n = "Sheet"
     return n
 
-def dedupe(base: str, existing: set[str]) -> str:
-    base = base[:_MAX_SHEET]
+
+def dedupe(base: str, existing: set[str], max_length: int | None = _MAX_SHEET) -> str:
+    if max_length is not None:
+        base = base[:max_length]
+
     if base not in existing:
         existing.add(base)
         return base
@@ -25,10 +32,13 @@ def dedupe(base: str, existing: set[str]) -> str:
     i = 2
     while True:
         suffix = f"_{i}"
-        trim = _MAX_SHEET - len(suffix)
-        core = base[:trim] if trim > 0 else ""
-        name = f"{core}{suffix}"[-_MAX_SHEET:]
-        if name not in existing and len(name) <= _MAX_SHEET:
-            existing.add(name)
-            return name
+        if max_length is None:
+            candidate = f"{base}{suffix}"
+        else:
+            trim = max_length - len(suffix)
+            core = base[:trim] if trim > 0 else ""
+            candidate = f"{core}{suffix}"[-max_length:]
+        if candidate not in existing and (max_length is None or len(candidate) <= max_length):
+            existing.add(candidate)
+            return candidate
         i += 1

--- a/src/excelmgr/core/sinks.py
+++ b/src/excelmgr/core/sinks.py
@@ -24,7 +24,11 @@ class _CsvSink:
             header_frame.to_csv(self._handle, index=False)
             self._header_written = True
         if not df.empty:
-            df.to_csv(self._handle, index=False, header=False)
+            if self._columns is None:
+                aligned = df
+            else:
+                aligned = df.reindex(columns=self._columns)
+            aligned.to_csv(self._handle, index=False, header=False)
 
     def finalize(self) -> None:
         if not self._header_written and self._columns is not None:

--- a/src/excelmgr/core/split.py
+++ b/src/excelmgr/core/split.py
@@ -67,7 +67,7 @@ def split(plan: SplitPlan, reader: WorkbookReader, writer: WorkbookWriter) -> di
     ext_map = {"xlsx": ".xlsx", "csv": ".csv", "parquet": ".parquet"}
     for k, g in parts:
         name = sanitize_sheet_name(str(k)) or "Empty"
-        unique = dedupe(name, seen_files)
+        unique = dedupe(name, seen_files, max_length=None)
         suffix = ext_map[plan.output_format]
         out_path = base_dir / f"{unique}{suffix}"
         if not plan.dry_run:

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from excelmgr.core.combine import combine
+from excelmgr.core.combine import _iter_input_files, combine
 from excelmgr.core.models import CombinePlan
 
 
@@ -83,3 +83,13 @@ def test_combine_uses_password_map_and_streaming(tmp_path: Path) -> None:
     assert [call[2] for call in reader.read_calls] == ["default", "special"]
     assert len(writer.appended) == 2
     assert all("password" in df.columns for df in writer.appended)
+
+
+def test_iter_input_files_skips_lock_files(tmp_path: Path) -> None:
+    lock = tmp_path / "~$open.xlsx"
+    lock.touch()
+    reader = StubReader()
+
+    files = list(_iter_input_files(reader, [str(lock)], None, False))
+
+    assert files == []

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -5,6 +5,11 @@ def test_sanitize_basic():
     assert sanitize_sheet_name("  /Weird:Name*  ") == "Weird_Name_"
     assert sanitize_sheet_name("") == "Empty"
 
+
+def test_sanitize_illegal_characters():
+    result = sanitize_sheet_name("Name:?[]*/\\")
+    assert result == "Name_______"
+
 def test_dedupe():
     s = set()
     a = dedupe("Data", s)
@@ -21,3 +26,22 @@ def test_dedupe_truncates_when_max_length():
     assert first == base
     assert second.endswith("_2")
     assert len(second) <= 31
+
+
+def test_dedupe_handles_multiple_full_length_names():
+    s: set[str] = set()
+    base = "y" * 31
+    names = [dedupe(base, s) for _ in range(3)]
+    assert names[0] == base
+    assert names[1].endswith("_2")
+    assert names[2].endswith("_3")
+    assert all(len(n) <= 31 for n in names)
+
+
+def test_dedupe_without_max_length_allows_long_names():
+    s: set[str] = set()
+    base = "abc" * 20
+    first = dedupe(base, s, max_length=None)
+    second = dedupe(base, s, max_length=None)
+    assert first == base
+    assert second == f"{base}_2"

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -1,0 +1,18 @@
+import pandas as pd
+
+from excelmgr.core.sinks import csv_sink
+
+
+def test_csv_sink_aligns_columns(tmp_path):
+    out = tmp_path / "out.csv"
+    df1 = pd.DataFrame({"A": [1], "B": [2]})
+    df2 = pd.DataFrame({"B": [3], "A": [4]})
+
+    with csv_sink(str(out)) as sink:
+        sink.append(df1)
+        sink.append(df2)
+
+    contents = out.read_text().strip().splitlines()
+    assert contents[0] == "A,B"
+    assert contents[1] == "1,2"
+    assert contents[2] == "4,3"

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import pandas as pd
+
+from excelmgr.core.models import SplitPlan
+from excelmgr.core.split import split
+
+
+class DummyReader:
+    def read_sheet(self, path: str, sheet: str | int, password: str | None = None) -> pd.DataFrame:
+        return pd.DataFrame({
+            "Category": ["A/B", "A:B"],
+            "Value": [1, 2],
+        })
+
+
+class DummyWriter:
+    def write_single_sheet(self, df: pd.DataFrame, out_path: str, sheet_name: str = "Data") -> None:  # pragma: no cover - unused
+        raise AssertionError("write_single_sheet should not be called for CSV split")
+
+    def write_multi_sheets(self, mapping, out_path: str) -> None:  # pragma: no cover - unused
+        raise AssertionError("write_multi_sheets should not be called for CSV split")
+
+    def stream_single_sheet(self, out_path: str, sheet_name: str = "Data"):  # pragma: no cover - unused
+        raise AssertionError("stream_single_sheet should not be called for CSV split")
+
+
+def test_split_dedupes_file_names(tmp_path: Path) -> None:
+    plan = SplitPlan(
+        input_file="ignored.xlsx",
+        by_column="Category",
+        to="files",
+        output_dir=str(tmp_path),
+        output_format="csv",
+        dry_run=False,
+    )
+
+    result = split(plan, DummyReader(), DummyWriter())
+
+    files = sorted(p.name for p in tmp_path.iterdir())
+    assert files == ["A_B.csv", "A_B_2.csv"]
+    assert result["count"] == 2


### PR DESCRIPTION
## Summary
- harden sheet-name sanitization and make dedupe support unlimited lengths for filenames
- ensure split file outputs deduplicate sanitized collisions and skip Excel lock files during traversal
- align CSV streaming output columns and extend test coverage for new behaviors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d519e1bbec832eb718e2744b5349b9