### PR TITLE
Add progress hooks and flexible split handling

### DIFF
--- a/src/excelmgr/core/models.py
+++ b/src/excelmgr/core/models.py
@@ -1,5 +1,4 @@
 from collections.abc import Mapping, Sequence
-from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Literal
 

--- a/src/excelmgr/core/progress.py
+++ b/src/excelmgr/core/progress.py
@@ -1,0 +1,29 @@
+"""Utilities for reporting progress events from core operations."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Callable
+
+
+ProgressHook = Callable[[str, dict[str, object]], None]
+
+
+def emit_progress(hooks: Sequence[ProgressHook], event: str, **payload: object) -> None:
+    """Notify all hooks about a progress event.
+
+    Parameters
+    ----------
+    hooks:
+        A sequence of callback functions to be invoked. Each callback receives
+        the event name followed by a payload dictionary describing the event.
+    event:
+        The name of the progress event being emitted.
+    payload:
+        Arbitrary keyword arguments describing the event context.
+    """
+
+    if not hooks:
+        return
+    for hook in hooks:
+        hook(event, dict(payload))

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -40,3 +40,38 @@ def test_split_dedupes_file_names(tmp_path: Path) -> None:
     files = sorted(p.name for p in tmp_path.iterdir())
     assert files == ["A_B.csv", "A_B_2.csv"]
     assert result["count"] == 2
+
+
+def test_split_supports_index_spec_and_progress(tmp_path: Path) -> None:
+    class IndexReader:
+        def read_sheet(self, path: str, sheet: str | int, password: str | None = None) -> pd.DataFrame:
+            return pd.DataFrame({
+                "Category": [1, 2],
+                "Value": [10, 20],
+            })
+
+    events: list[tuple[str, dict[str, object]]] = []
+
+    def _hook(event: str, payload: dict[str, object]) -> None:
+        events.append((event, payload))
+
+    plan = SplitPlan(
+        input_file="ignored.xlsx",
+        by_column="index:0",
+        to="files",
+        output_dir=str(tmp_path),
+        output_format="csv",
+        dry_run=True,
+    )
+
+    result = split(plan, IndexReader(), DummyWriter(), progress_hooks=[_hook])
+
+    assert [event for event, _ in events] == [
+        "split_start",
+        "split_partition",
+        "split_partition",
+        "split_complete",
+    ]
+    assert events[1][1]["rows"] == 1
+    assert events[-1][1]["partitions"] == 2
+    assert result["count"] == 2


### PR DESCRIPTION
## Summary
- add a reusable progress hook utility and wire it into combine and split operations
- extend combine/split/plan execution and CLI commands to surface structured progress events
- support column index specifiers in split plans and add regression tests for hooks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5238cd47c832ea6d0bdd2d66f69e0