### PR TITLE
Improve interactive UX and Unicode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ Choose log format and destination:
 excelmgr --log text --log-level INFO --log-file excelmgr.log combine ./data --out combined.xlsx
 ```
 
+## Encoding
+- All text I/O defaults to UTF-8. Readers transparently accept UTF-8 with or without BOMs so headers such as `Müşteri Adı` or `年` stay intact.
+- Interactive mode preserves Unicode in filenames, sheet names, column headers, previews, and JSON logs (no `\uXXXX` escaping).
+- When exporting CSV/TSV, files are written as UTF-8 without a BOM by default. Enable the optional **“Add UTF-8 BOM for compatibility?”** toggle in the format menu if a legacy consumer requires it.
+
 ## Exit codes
 - `0` success
 - `2` known error (e.g., sheet not found, decryption)

--- a/src/excelmgr/adapters/json_logger.py
+++ b/src/excelmgr/adapters/json_logger.py
@@ -38,7 +38,7 @@ class JsonLogger:
             keys = sorted(k for k in payload if k not in {"event", "ts", "run_id", "level"})
             parts = " ".join(f"{key}={payload[key]}" for key in keys)
             return f"[{payload['level']}] {payload['event']} {parts}".rstrip()
-        return json.dumps(payload)
+        return json.dumps(payload, ensure_ascii=False)
 
     def _emit(self, event: str, *, level: str, **kwargs: Any) -> None:
         payload: dict[str, Any] = {

--- a/src/excelmgr/cli/main.py
+++ b/src/excelmgr/cli/main.py
@@ -184,7 +184,7 @@ def combine(
             progress_hooks=[hook],
         )
         logger.info("combine_completed", **result)
-        print(json.dumps(result, indent=2))
+        print(json.dumps(result, indent=2, ensure_ascii=False))
     except typer.Exit:
         raise
     except ExcelMgrError as exc:
@@ -253,7 +253,7 @@ def split(
             progress_hooks=[hook],
         )
         logger.info("split_completed", **result)
-        print(json.dumps(result, indent=2))
+        print(json.dumps(result, indent=2, ensure_ascii=False))
     except typer.Exit:
         raise
     except ExcelMgrError as exc:
@@ -284,7 +284,7 @@ def preview(
         plan = PreviewPlan(path=path, password=pw, password_map=pw_map, limit=limit)
         result = preview_command(plan, PandasReader())
         logger.info("preview_completed", path=path, sheets=len(result.get("sheets", [])))
-        print(json.dumps(result, indent=2))
+        print(json.dumps(result, indent=2, ensure_ascii=False))
     except typer.Exit:
         raise
     except ExcelMgrError as exc:
@@ -388,7 +388,7 @@ def delete_cols(
             progress_hooks=[hook],
         )
         logger.info("delete_cols_completed", **result)
-        print(json.dumps(result, indent=2))
+        print(json.dumps(result, indent=2, ensure_ascii=False))
     except typer.Exit:
         raise
     except ExcelMgrError as exc:
@@ -414,7 +414,7 @@ def plan(
             progress_hooks=[hook],
         )
         logger.info("plan_completed", operations=len(results))
-        print(json.dumps({"operations": results}, indent=2))
+    print(json.dumps({"operations": results}, indent=2, ensure_ascii=False))
     except typer.Exit:
         raise
     except ExcelMgrError as exc:
@@ -444,7 +444,7 @@ def diagnose():
             "macro_policy": settings.macro_policy,
         },
     }
-    print(json.dumps(info, indent=2))
+    print(json.dumps(info, indent=2, ensure_ascii=False))
 
 
 @app.command(help="Show version.")

--- a/src/excelmgr/cli/options.py
+++ b/src/excelmgr/cli/options.py
@@ -4,6 +4,7 @@ import typer
 
 from excelmgr.core.errors import ExcelMgrError
 from excelmgr.core.password_maps import load_password_map
+from excelmgr.util.text import read_text
 
 
 def read_secret(password: str | None, password_env: str | None, password_file: str | None) -> str | None:
@@ -13,8 +14,7 @@ def read_secret(password: str | None, password_env: str | None, password_file: s
         return os.environ.get(password_env)
     if password_file:
         try:
-            with open(password_file, encoding="utf-8") as f:
-                return f.read().strip()
+            return read_text(password_file).strip()
         except FileNotFoundError:
             raise typer.BadParameter(f"Password file not found: {password_file}") from None
     return None

--- a/src/excelmgr/core/combine.py
+++ b/src/excelmgr/core/combine.py
@@ -101,7 +101,7 @@ def combine(
             if plan.output_format == "xlsx":
                 sink_cm = writer.stream_single_sheet(plan.output_path, sheet_name=plan.output_sheet_name)
             elif plan.output_format == "csv":
-                sink_cm = csv_sink(plan.output_path)
+                sink_cm = csv_sink(plan.output_path, add_bom=plan.csv_add_bom)
             elif plan.output_format == "parquet":
                 sink_cm = parquet_sink(plan.output_path)
             else:  # pragma: no cover - guarded by CLI validation

--- a/src/excelmgr/core/models.py
+++ b/src/excelmgr/core/models.py
@@ -43,6 +43,7 @@ class CombinePlan:
     password: str | None = None
     password_map: Mapping[str, str] | None = None
     output_format: Literal["xlsx", "csv", "parquet"] = "xlsx"
+    csv_add_bom: bool = False
     dry_run: bool = False
     destination: Destination | None = None
 
@@ -60,6 +61,7 @@ class SplitPlan:
     password: str | None = None
     password_map: Mapping[str, str] | None = None
     output_format: Literal["xlsx", "csv", "parquet"] = "xlsx"
+    csv_add_bom: bool = False
     dry_run: bool = False
     destination: Destination | None = None
 

--- a/src/excelmgr/core/plan_runner.py
+++ b/src/excelmgr/core/plan_runner.py
@@ -25,6 +25,7 @@ from excelmgr.core.password_maps import load_password_map
 from excelmgr.core.preview import preview
 from excelmgr.core.progress import ProgressHook
 from excelmgr.core.split import split
+from excelmgr.util.text import read_text
 from excelmgr.ports.readers import WorkbookReader
 from excelmgr.ports.writers import CloudObjectWriter, TableWriter, WorkbookWriter
 
@@ -173,6 +174,7 @@ def _build_combine_plan(entry: Mapping, base_dir: Path) -> CombinePlan:
         password=entry.get("password"),
         password_map=password_map,
         output_format=str(entry.get("output_format", "xlsx")),
+        csv_add_bom=bool(entry.get("csv_add_bom", False)),
         dry_run=bool(entry.get("dry_run", False)),
         destination=destination,
     )
@@ -204,6 +206,7 @@ def _build_split_plan(entry: Mapping, base_dir: Path) -> SplitPlan:
         password=entry.get("password"),
         password_map=password_map,
         output_format=str(entry.get("output_format", "xlsx")),
+        csv_add_bom=bool(entry.get("csv_add_bom", False)),
         dry_run=bool(entry.get("dry_run", False)),
         destination=destination,
     )
@@ -284,9 +287,9 @@ def load_plan_file(path: str) -> list[PlanOperation]:
             import yaml
         except ImportError as exc:  # pragma: no cover - optional dependency
             raise ExcelMgrError("YAML plan support requires the 'PyYAML' package.") from exc
-        data = yaml.safe_load(plan_path.read_text(encoding="utf-8"))
+        data = yaml.safe_load(read_text(plan_path))
     else:
-        data = json.loads(plan_path.read_text(encoding="utf-8"))
+        data = json.loads(read_text(plan_path))
 
     if data is None:
         return []

--- a/src/excelmgr/core/split.py
+++ b/src/excelmgr/core/split.py
@@ -146,7 +146,7 @@ def split(
             if plan.output_format == "xlsx":
                 writer.write_single_sheet(g, str(out_path), sheet_name=plan.output_sheet_name)
             elif plan.output_format == "csv":
-                with csv_sink(str(out_path)) as sink:
+                with csv_sink(str(out_path), add_bom=plan.csv_add_bom) as sink:
                     sink.append(g)
             elif plan.output_format == "parquet":
                 with parquet_sink(str(out_path)) as sink:

--- a/src/excelmgr/util/__init__.py
+++ b/src/excelmgr/util/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for Excel Manager."""

--- a/src/excelmgr/util/text.py
+++ b/src/excelmgr/util/text.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+
+_UTF8_FALLBACKS: tuple[str, ...] = ("utf-8-sig", "utf-8")
+
+
+def read_text(path: str | Path, encoding: str | None = None) -> str:
+    target = Path(path)
+    attempts: Iterable[str]
+    if encoding:
+        attempts = (encoding,)
+    else:
+        attempts = _UTF8_FALLBACKS
+    last_error: Exception | None = None
+    for enc in attempts:
+        try:
+            return target.read_text(encoding=enc)
+        except Exception as exc:  # pragma: no cover - bubbled after retries
+            last_error = exc
+    if last_error:
+        raise last_error
+    raise ValueError("No encoding attempts were made.")
+
+
+def write_text(path: str | Path, data: str, *, encoding: str = "utf-8", add_bom: bool = False) -> None:
+    target = Path(path)
+    text = data
+    if add_bom and not text.startswith("\ufeff"):
+        text = "\ufeff" + text
+    target.write_text(text, encoding=encoding)

--- a/tests/test_unicode_encoding.py
+++ b/tests/test_unicode_encoding.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from typer.testing import CliRunner
+
+from excelmgr.cli.interactive import _compose_filename, pick_sheets
+from excelmgr.cli.main import app
+from excelmgr.core.password_maps import load_password_map
+from excelmgr.core.sinks import csv_sink
+from excelmgr.util.text import read_text, write_text
+
+
+def test_filename_sanitize_unicode(tmp_path: Path) -> None:
+    name = _compose_filename(
+        base="ميزان/تجريبي",
+        src=None,
+        sheet="بيانات العملاء",
+        extra="年報",
+        timestamp="20250101_010101",
+        suffix=".xlsx",
+    )
+    assert name == "ميزان_تجريبي__بيانات العملاء__年報__20250101_010101.xlsx"
+
+    src = tmp_path / "اسم.xlsx"
+    src.write_text("dummy", encoding="utf-8")
+    deduped = _compose_filename(
+        base=None,
+        src=src,
+        sheet="اسم",
+        extra="اسم",
+        timestamp="20250101_010101",
+        suffix=".xlsx",
+    )
+    assert deduped.startswith("اسم__20250101_010101")
+
+
+def test_csv_bom_handling(tmp_path: Path) -> None:
+    bom_csv = tmp_path / "pw.csv"
+    write_text(bom_csv, "path,password\nÜnicøde.xlsx,密码\n", add_bom=True)
+    mapping = load_password_map(str(bom_csv))
+    assert mapping == {"Ünicøde.xlsx": "密码"}
+
+    df = pd.DataFrame({"Müşteri Adı": ["Ada"]})
+    out_plain = tmp_path / "plain.csv"
+    with csv_sink(str(out_plain)) as sink:
+        sink.append(df)
+    raw_plain = out_plain.read_bytes()
+    assert not raw_plain.startswith("\ufeff".encode("utf-8"))
+    assert read_text(out_plain).splitlines()[0] == "Müşteri Adı"
+
+    out_bom = tmp_path / "bom.csv"
+    with csv_sink(str(out_bom), add_bom=True) as sink:
+        sink.append(df)
+    raw_bom = out_bom.read_bytes()
+    assert raw_bom.startswith("\ufeff".encode("utf-8"))
+
+
+def test_sheet_picker_unicode(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    names = ["Résumé ✅", "بيانات العملاء"]
+    monkeypatch.setattr("excelmgr.cli.interactive._list_sheet_names", lambda path, password: names)
+
+    responses = iter(["1"])
+    monkeypatch.setattr(
+        "excelmgr.cli.interactive.typer.prompt",
+        lambda message, **kwargs: next(responses),
+    )
+    selected = pick_sheets("dummy.xlsx", password=None, allow_multi=False, allow_all=False)
+    assert selected == [names[0]]
+    out = capsys.readouterr().out
+    assert "1) Résumé ✅" in out
+
+    responses = iter(["ré"])
+    monkeypatch.setattr(
+        "excelmgr.cli.interactive.typer.prompt",
+        lambda message, **kwargs: next(responses),
+    )
+    selected_prefix = pick_sheets("dummy.xlsx", password=None, allow_multi=False, allow_all=False)
+    assert selected_prefix == [names[0]]
+
+
+def test_welcome_once() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, [], input="0\n8\n")
+    assert result.exit_code == 0
+    welcome_line = "Welcome to Excel Manager — a guided CLI for combining, splitting, previewing, and fixing Excel files."
+    assert result.output.count(welcome_line) == 1
+    assert result.output.count("Select an action") >= 2


### PR DESCRIPTION
## Summary
- show a single welcome banner before the interactive main menu and improve Unicode-aware menu navigation
- add UTF-8 first text helpers, allow optional CSV BOM emission, and keep Unicode in filenames, JSON logs, and prompts
- document the UTF-8 defaults and add tests covering Unicode filenames, sheet selection, BOM handling, and one-time welcome logic

## Testing
- `pytest -q -o addopts=""` *(fails: missing pandas/typer dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d829ad0b54832eba98b46ae6a6a19d