### PR TITLE
Fix CLI JSON output and interactive prompts

### DIFF
--- a/src/excelmgr/cli/main.py
+++ b/src/excelmgr/cli/main.py
@@ -6,7 +6,6 @@ import sys
 from typing import Annotated, Literal
 
 import typer
-from rich import print
 from typer.core import TyperOption
 
 from excelmgr.adapters.json_logger import JsonLogger
@@ -39,6 +38,12 @@ _patch_typer_option()
 
 
 app = typer.Typer(invoke_without_command=True, add_completion=False, rich_markup_mode=None)
+
+
+def _echo_json(payload: object) -> None:
+    """Emit a JSON payload without ANSI styling so tests can parse it."""
+
+    typer.echo(json.dumps(payload, indent=2, ensure_ascii=False), color=False)
 
 
 def _make_logger(fmt: str, level: str, file: str | None):
@@ -184,7 +189,7 @@ def combine(
             progress_hooks=[hook],
         )
         logger.info("combine_completed", **result)
-        print(json.dumps(result, indent=2, ensure_ascii=False))
+        _echo_json(result)
     except typer.Exit:
         raise
     except ExcelMgrError as exc:
@@ -253,7 +258,7 @@ def split(
             progress_hooks=[hook],
         )
         logger.info("split_completed", **result)
-        print(json.dumps(result, indent=2, ensure_ascii=False))
+        _echo_json(result)
     except typer.Exit:
         raise
     except ExcelMgrError as exc:
@@ -284,7 +289,7 @@ def preview(
         plan = PreviewPlan(path=path, password=pw, password_map=pw_map, limit=limit)
         result = preview_command(plan, PandasReader())
         logger.info("preview_completed", path=path, sheets=len(result.get("sheets", [])))
-        print(json.dumps(result, indent=2, ensure_ascii=False))
+        _echo_json(result)
     except typer.Exit:
         raise
     except ExcelMgrError as exc:
@@ -388,7 +393,7 @@ def delete_cols(
             progress_hooks=[hook],
         )
         logger.info("delete_cols_completed", **result)
-        print(json.dumps(result, indent=2, ensure_ascii=False))
+        _echo_json(result)
     except typer.Exit:
         raise
     except ExcelMgrError as exc:
@@ -414,7 +419,7 @@ def plan(
             progress_hooks=[hook],
         )
         logger.info("plan_completed", operations=len(results))
-    print(json.dumps({"operations": results}, indent=2, ensure_ascii=False))
+        _echo_json({"operations": results})
     except typer.Exit:
         raise
     except ExcelMgrError as exc:
@@ -444,11 +449,11 @@ def diagnose():
             "macro_policy": settings.macro_policy,
         },
     }
-    print(json.dumps(info, indent=2, ensure_ascii=False))
+    _echo_json(info)
 
 
 @app.command(help="Show version.")
 def version():
     from excelmgr import __version__
 
-    print(__version__)
+    typer.echo(__version__)


### PR DESCRIPTION
## Summary
- emit JSON responses with typer.echo to avoid ANSI sequences in CLI output
- harden the interactive menu by handling aborts, adding a toggle shortcut, and showing a Main menu header
- reorder the combine workflow prompts, allow optional output paths, and add a "done" option to the password selector while tolerating missing files when deriving output folders

## Testing
- `uv run python - <<'PY'
from pathlib import Path
import pandas as pd
from typer.testing import CliRunner
from excelmgr.cli.main import app

runner = CliRunner()
with runner.isolated_filesystem():
    df1 = pd.DataFrame({"Region": ["North"], "Value": [10]})
    df2 = pd.DataFrame({"Region": ["South"], "Value": [20]})
    df1.to_excel("north.xlsx", index=False, sheet_name="North")
    df2.to_excel("south.xlsx", index=False, sheet_name="South")
    plan_text = """
operations:
  - type: combine
    name: combine_cloud
    options:
      inputs:
        - north.xlsx
        - south.xlsx
      output_format: csv
      output_path: combined_local.csv
      destination:
        kind: cloud
        root: cloud-bucket
        key: combined.csv
        format: csv
  - type: preview
    name: inspect
    options:
      path: north.xlsx
      limit: 1
"""
    Path("batch.yaml").write_text(plan_text, encoding="utf-8")
    result = runner.invoke(app, ["plan", "batch.yaml"], catch_exceptions=False)
    print(result.exit_code)
    print(result.stdout)
PY`
- `uv run python - <<'PY'
from typer.testing import CliRunner
from excelmgr.cli.main import app

runner = CliRunner()
result = runner.invoke(app, [], input='8\n')
print(result.exit_code)
print('Main menu' in result.output)
print(result.output)
PY`
- `uv run python - <<'PY'
from typer.testing import CliRunner
import excelmgr.cli.interactive as interactive
from excelmgr.cli.main import app

captured = {}

def fake_reader():
    return "reader"

def fake_writer():
    return "writer"

def fake_combine(plan, reader, writer, progress_hooks):
    captured['plan'] = plan
    return {"output_path": plan.output_path}

interactive.PandasReader = fake_reader
interactive.PandasWriter = fake_writer
interactive.combine_command = fake_combine

runner = CliRunner()
input_steps = [
    "1",
    "file.xlsx",
    "1",
    "",
    "n",
    "",
    "",
    "",
    "n",
    "1",
    "y",
    "5",
    "2",
    "8",
]
result = runner.invoke(app, [], input="\n".join(input_steps) + "\n")
print('exit', result.exit_code)
print('combine workflow', 'Combine workflow' in result.output)
print('plan dry run', captured['plan'].dry_run)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68d8309060f4832eb64a0544bd979b7c